### PR TITLE
Only include credo and dialyzer packages in dev and test

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -37,8 +37,8 @@ defmodule PlugStaticIndexHtml.Mixfile do
     [
       {:plug, "~> 1.0"},
       {:ex_doc, ">= 0.13.0", only: :dev},
-      {:dialyxir, "~> 0.5", runtime: false},
-      {:credo, ">= 0.0.0", runtime: false}
+      {:dialyxir, "~> 0.5", only: [:dev, :test], runtime: false},
+      {:credo, ">= 0.0.0", only: [:dev, :test], runtime: false}
     ]
   end
 end


### PR DESCRIPTION
When I tried to `update plug_static_index_html` to version 0.1.3 in a project, I got the following errors when running `mix deps.get`

```
Dependencies have diverged:
* dialyxir (Hex package)
  the :only option for dependency dialyxir

  > In mix.exs:
    {:dialyxir, "~> 0.5", [env: :prod, repo: "hexpm", hex: "dialyxir", only: [:dev, :test], runtime: false, manager: :mix]}

  does not match the :only option calculated for

  > In deps/plug_static_index_html/mix.exs:
    {:dialyxir, "~> 0.5", [env: :prod, hex: "dialyxir", repo: "hexpm", optional: false]}

  Remove the :only restriction from your dep
* credo (Hex package)
  the :only option for dependency credo

  > In apps/xxx/mix.exs:
    {:credo, "~> 0.8.1", [env: :prod, repo: "hexpm", hex: "credo", only: [:dev, :test], manager: :mix]}

  does not match the :only option calculated for

  > In deps/plug_static_index_html/mix.exs:
    {:credo, ">= 0.0.0", [env: :prod, hex: "credo", repo: "hexpm", optional: false]}

  Remove the :only restriction from your dep
** (Mix) Can't continue due to errors on dependencies
```